### PR TITLE
Fix: Installation/Bash Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the contents of this repository.
 Running the automation script below to setup everything:
 
 ```console
-curl -fsSL "https://tinyurl.com/setup-dots" | bash -c
+bash -c "$(curl -fsSL 'https://tinyurl.com/setup-dots')"
 ```
 
 <details>


### PR DESCRIPTION
# Fix: Installation/Bash Command in README

## Description

### Error:
The earlier bash script ``curl -fsSL "https://tinyurl.com/setup-dots" | bash -c`` was showing an error because of the ``bash -c`` argument in the end. And it showed an error which was as follows:
```error
bash: -c: option requires an argument
curl: (23) Failure writing output to destination
```

### Fix:
After Digging down into the rabbit hole with very little knowledge of Bash. I finally figured out the cause which was that the ``-c`` flag in Bash requires a string or a command in a string format to execute.
So, the new command and the changes I made is as follows:
```console
bash -c "$(curl -fsSL 'https://tinyurl.com/setup-dots')"
```

### Drawbacks:
Now that the new bash command is working as we are expecting it to, The installation script shows an error. The error is given below:
```
[INFO] Starting local development environment setup now...
[WARN] System update failed...please ensure to do afterwards
[INFO] Setting patched Nerd Fonts for local usage...
fc-cache: invalid option -- 'e'
usage: fc-cache [-EfrsvVh] [-y SYSROOT] [--error-on-no-fonts] [--force|--really-force] [--sysroot=SYSROOT] [--system-only] [--verbose] [--version] [--help] [dirs]
```

I am 99.9% sure that there is not an error in the new bash command which I fixed and there is something wrong in the installation script itself. 

## Type of change
- [*] Bug fix (non-breaking change which fixes an issue)
- [*] This change requires a documentation update

## Is it Tested
Yes.

## Does it work flawlessly on a Ubuntu Machine?
Yes, atleast on WSL.

## Configurations
- Ubuntu(WSL) version: ``22.04.2 LTS``
- Bash version: ``5.1.16(1)-release (x86_64-pc-linux-gnu)``
- Windows version: ``21H2``