### PR TITLE
chore: configure Neovim to be able to identify Caddyfiles

### DIFF
--- a/dotfiles/.config/nvim/filetype.lua
+++ b/dotfiles/.config/nvim/filetype.lua
@@ -15,6 +15,7 @@ vim.filetype.add({
     [".env"] = "dotenv",
     ["env"] = "dotenv",
     ["tsconfig.json"] = "jsonc",
+    ["Caddyfile"] = "Caddyfile",
   },
   -- Detect and apply filetypes based on certain patterns of the filenames
   pattern = {


### PR DESCRIPTION
This PR updates the Neovim configurations to add Treesitter queries for Caddyfiles (read "[The Caddyfile -- Caddy Documentation](https://caddyserver.com/docs/caddyfile)" for more information.