### PR TITLE
chore(nvim): add the LSP server for `fish`

### DIFF
--- a/dotfiles/.config/nvim/init.lua
+++ b/dotfiles/.config/nvim/init.lua
@@ -85,4 +85,4 @@ vim.loader.enable()
 require("statusline").setup()
 
 -- Enable the required LSP servers
-vim.lsp.enable({ "lua_ls" })
+vim.lsp.enable({ "lua_ls", "fish_lsp" })

--- a/dotfiles/.config/nvim/lua/plugins/mason.lua
+++ b/dotfiles/.config/nvim/lua/plugins/mason.lua
@@ -31,6 +31,7 @@ return {
         "debugpy",
         "dockerfile-language-server",
         "eslint-lsp",
+        "fish-lsp",
         "goimports-reviser",
         "golines",
         "gopls",


### PR DESCRIPTION
This PR configures Mason to keep track of and manage the LSP server for `fish` and also enables it for Neovim to use for its LSP client.